### PR TITLE
Problem kolejnosci wczytywania modulow

### DIFF
--- a/Base classes/Kernel/BaseKernel.pas
+++ b/Base classes/Kernel/BaseKernel.pas
@@ -1,0 +1,32 @@
+unit BaseKernel;
+
+interface
+
+uses
+  InterfaceKernel, InterfaceModule, System.Generics.Collections;
+
+type
+  TBaseKernel = class (TInterfacedObject, IBaseKernel)
+  strict private
+    FBaseKernel : IBaseKernel;
+  public
+    procedure RegisterModules (p_ModuleList : TList<IModule>); virtual;
+    procedure SetBaseKernel (p_Kernel : IBaseKernel);
+  end;
+
+implementation
+
+{ TBaseKernel }
+
+procedure TBaseKernel.RegisterModules(p_ModuleList: TList<IModule>);
+begin
+  if Assigned (FBaseKernel) then
+    FBaseKernel.RegisterModules (p_ModuleList);
+end;
+
+procedure TBaseKernel.SetBaseKernel(p_Kernel: IBaseKernel);
+begin
+  FBaseKernel := p_Kernel;
+end;
+
+end.

--- a/Base classes/Kernel/BaseKernel.pas
+++ b/Base classes/Kernel/BaseKernel.pas
@@ -6,27 +6,27 @@ uses
   InterfaceKernel, InterfaceModule, System.Generics.Collections;
 
 type
-  TBaseKernel = class (TInterfacedObject, IBaseKernel)
+  TBasePlatform = class (TInterfacedObject, IPlatform)
   strict private
-    FBaseKernel : IBaseKernel;
+    FBaseKernel : IPlatform;
   public
     procedure RegisterModules (p_ModuleList : TList<IModule>); virtual;
-    procedure SetBaseKernel (p_Kernel : IBaseKernel);
+    procedure SetBasePlatform (p_Platform: IPlatform);
   end;
 
 implementation
 
-{ TBaseKernel }
+{ TBasePlatform }
 
-procedure TBaseKernel.RegisterModules(p_ModuleList: TList<IModule>);
+procedure TBasePlatform.RegisterModules(p_ModuleList: TList<IModule>);
 begin
   if Assigned (FBaseKernel) then
     FBaseKernel.RegisterModules (p_ModuleList);
 end;
 
-procedure TBaseKernel.SetBaseKernel(p_Kernel: IBaseKernel);
+procedure TBasePlatform.SetBasePlatform(p_Platform: IPlatform);
 begin
-  FBaseKernel := p_Kernel;
+  FBaseKernel := p_Platform;
 end;
 
 end.

--- a/Base classes/Kernel/BaseKernel.pas
+++ b/Base classes/Kernel/BaseKernel.pas
@@ -6,27 +6,27 @@ uses
   InterfaceKernel, InterfaceModule, System.Generics.Collections;
 
 type
-  TBasePlatform = class (TInterfacedObject, IPlatform)
+  TContainer = class (TInterfacedObject, IContainer)
   strict private
-    FBaseKernel : IPlatform;
+    FBaseKernel : IContainer;
   public
     procedure RegisterModules (p_ModuleList : TList<IModule>); virtual;
-    procedure SetBasePlatform (p_Platform: IPlatform);
+    procedure SetContainer (p_Container: IContainer);
   end;
 
 implementation
 
-{ TBasePlatform }
+{ TContainer }
 
-procedure TBasePlatform.RegisterModules(p_ModuleList: TList<IModule>);
+procedure TContainer.RegisterModules(p_ModuleList: TList<IModule>);
 begin
   if Assigned (FBaseKernel) then
     FBaseKernel.RegisterModules (p_ModuleList);
 end;
 
-procedure TBasePlatform.SetBasePlatform(p_Platform: IPlatform);
+procedure TContainer.SetContainer(p_Container: IContainer);
 begin
-  FBaseKernel := p_Platform;
+  FBaseKernel := p_Container;
 end;
 
 end.

--- a/Base classes/Kernel/InterfaceKernel.pas
+++ b/Base classes/Kernel/InterfaceKernel.pas
@@ -9,11 +9,11 @@ type
   TFrameClass = class of TFrame;
   TKernelState = (ks_Loading, ks_Ready);
 
-  IPlatform = interface
+  IContainer = interface
   ['{3F76C9A4-0DA3-4EE4-AABC-F47A5C4C1D50}']
     procedure RegisterModules (p_ModuleList : TList<IModule>);
-    procedure SetBasePlatform (p_Platform : IPlatform);
-    property BasePlatform : IPlatform write SetBasePlatform;
+    procedure SetContainer (p_Container : IContainer);
+    property Container : IContainer write SetContainer;
   end;
 
   IMainKernel = interface
@@ -24,9 +24,9 @@ type
     procedure Open(p_MainFrame : TFrameClass; p_FrameTitle : string);
     function GiveObjectByInterface (p_GUID : TGUID; p_Silent : boolean = false) : IInterface;
     function GetState : TKernelState;
-    function GetBasePlatform : IPlatform;
+    function GetMainContainer : IContainer;
     property State : TKernelState read GetState;
-    property BasePlatform : IPlatform read GetBasePlatform;
+    property MainContainer : IContainer read GetMainContainer;
   end;
 
 implementation

--- a/Base classes/Kernel/InterfaceKernel.pas
+++ b/Base classes/Kernel/InterfaceKernel.pas
@@ -9,16 +9,21 @@ type
   TFrameClass = class of TFrame;
   TKernelState = (ks_Loading, ks_Ready);
 
-  IKernel = interface
+  IBaseKernel = interface
   ['{3F76C9A4-0DA3-4EE4-AABC-F47A5C4C1D50}']
+    procedure RegisterModules (p_ModuleList : TList<IModule>);
+    procedure SetBaseKernel (p_Kernel : IBaseKernel);
+    property BaseKernel : IBaseKernel write SetBaseKernel;
+  end;
+
+  IMainKernel = interface (IBaseKernel)
+  ['{1E3557B2-0A30-4880-8639-3F8A57295AEE}']
     procedure OpenModules;
     procedure CloseModules;
     procedure ReloadModules;
     procedure Run(p_MainFrame : TFrameClass; p_FrameTitle : string);
     function GiveObjectByInterface (p_GUID : TGUID; p_Silent : boolean = false) : IInterface;
-    function GetObjectList : TList<IModule>;
     function GetState : TKernelState;
-    property ObjectList: TList<IModule> read GetObjectList;
     property State : TKernelState read GetState;
   end;
 

--- a/Base classes/Kernel/InterfaceKernel.pas
+++ b/Base classes/Kernel/InterfaceKernel.pas
@@ -9,22 +9,24 @@ type
   TFrameClass = class of TFrame;
   TKernelState = (ks_Loading, ks_Ready);
 
-  IBaseKernel = interface
+  IPlatform = interface
   ['{3F76C9A4-0DA3-4EE4-AABC-F47A5C4C1D50}']
     procedure RegisterModules (p_ModuleList : TList<IModule>);
-    procedure SetBaseKernel (p_Kernel : IBaseKernel);
-    property BaseKernel : IBaseKernel write SetBaseKernel;
+    procedure SetBasePlatform (p_Platform : IPlatform);
+    property BasePlatform : IPlatform write SetBasePlatform;
   end;
 
-  IMainKernel = interface (IBaseKernel)
+  IMainKernel = interface
   ['{1E3557B2-0A30-4880-8639-3F8A57295AEE}']
     procedure OpenModules;
     procedure CloseModules;
     procedure ReloadModules;
-    procedure Run(p_MainFrame : TFrameClass; p_FrameTitle : string);
+    procedure Open(p_MainFrame : TFrameClass; p_FrameTitle : string);
     function GiveObjectByInterface (p_GUID : TGUID; p_Silent : boolean = false) : IInterface;
     function GetState : TKernelState;
+    function GetBasePlatform : IPlatform;
     property State : TKernelState read GetState;
+    property BasePlatform : IPlatform read GetBasePlatform;
   end;
 
 implementation

--- a/Base classes/Kernel/Kernel.pas
+++ b/Base classes/Kernel/Kernel.pas
@@ -3,29 +3,27 @@ unit Kernel;
 interface
 
 uses
-  InterfaceModule, System.Generics.Collections, WindowSkeleton, Vcl.Forms, InterfaceKernel;
+  InterfaceModule, System.Generics.Collections, WindowSkeleton, Vcl.Forms, InterfaceKernel, BaseKernel;
 
 type
-  TKernel = class (TInterfacedObject, IKernel)
-    protected
+  TKernel = class (TBaseKernel, IMainKernel)
+    strict private
       FObjectList : TList<IModule>;
+    protected
       FState : TKernelState;
     public
       constructor Create;
       destructor Destroy; override;
-      procedure OpenModules;
-      procedure CloseModules;
-      procedure ReloadModules;
+      procedure OpenModules; virtual;
+      procedure CloseModules; virtual;
+      procedure ReloadModules; virtual;
       procedure Run(p_MainFrame : TFrameClass; p_FrameTitle : string);
-      function GetObjectList : TList <IModule>;
       function GiveObjectByInterface (p_GUID : TGUID; p_Silent : boolean = false) : IInterface;
       function GetState : TKernelState;
-      property ObjectList: TList<IModule> read FObjectList;
-      property State : TKernelState read GetState;
   end;
 
 var
-  MainKernel : IKernel;
+  MainKernel : IMainKernel;
 
 implementation
 
@@ -51,11 +49,6 @@ begin
   inherited;
 end;
 
-function TKernel.GetObjectList: TList<IModule>;
-begin
-  Result := FObjectList;
-end;
-
 function TKernel.GetState: TKernelState;
 begin
   Result := FState;
@@ -78,6 +71,9 @@ var
   pomWind : TWndSkeleton;
 begin
   FState := ks_Loading;
+
+  RegisterModules (FObjectList);
+
   OpenModules;
 
   //open main window

--- a/Base classes/Kernel/Kernel.pas
+++ b/Base classes/Kernel/Kernel.pas
@@ -9,11 +9,11 @@ type
   TKernel = class (TInterfacedObject, IMainKernel)
     strict private
       FObjectList : TList<IModule>;
-      FBaseKernel : IPlatform;
+      FContainer : IContainer;
     protected
       FState : TKernelState;
     public
-      constructor Create (p_BaseKernel : IPlatform);
+      constructor Create (p_BaseKernel : IContainer);
       destructor Destroy; override;
       procedure OpenModules; virtual;
       procedure CloseModules; virtual;
@@ -21,7 +21,7 @@ type
       procedure Open (p_MainFrame : TFrameClass; p_FrameTitle : string);
       function GiveObjectByInterface (p_GUID : TGUID; p_Silent : boolean = false) : IInterface;
       function GetState : TKernelState;
-      function GetBasePlatform : IPlatform;
+      function GetMainContainer : IContainer;
   end;
 
 var
@@ -40,10 +40,10 @@ begin
     FObjectList [i].CloseModule;
 end;
 
-constructor TKernel.Create (p_BaseKernel : IPlatform);
+constructor TKernel.Create (p_BaseKernel : IContainer);
 begin
   FObjectList := TList<IModule>.Create;
-  FBaseKernel := p_BaseKernel;
+  FContainer := p_BaseKernel;
 end;
 
 destructor TKernel.Destroy;
@@ -52,9 +52,9 @@ begin
   inherited;
 end;
 
-function TKernel.GetBasePlatform: IPlatform;
+function TKernel.GetMainContainer: IContainer;
 begin
-  Result := FBaseKernel;
+  Result := FContainer;
 end;
 
 function TKernel.GetState: TKernelState;
@@ -80,9 +80,9 @@ var
 begin
   FState := ks_Loading;
 
-  if not Assigned (FBaseKernel) then
+  if not Assigned (FContainer) then
     Exit;
-  FBaseKernel.RegisterModules (FObjectList);
+  FContainer.RegisterModules (FObjectList);
 
   OpenModules;
 

--- a/Common classes/TransactionAnalyzerKernel.pas
+++ b/Common classes/TransactionAnalyzerKernel.pas
@@ -3,10 +3,10 @@ unit TransactionAnalyzerKernel;
 interface
 
 uses
-  InterfaceModule, System.Generics.Collections, InterfaceKernel, Kernel;
+  InterfaceModule, System.Generics.Collections, InterfaceKernel, BaseKernel;
 
 type
-  TTransactionAnalyzerKernel = class(TKernel, IBaseKernel)
+  TTransactionAnalyzerKernel = class(TBasePlatform, IPlatform)
     procedure RegisterModules (p_ModuleList : TList<IModule>); override;
   end;
 

--- a/Common classes/TransactionAnalyzerKernel.pas
+++ b/Common classes/TransactionAnalyzerKernel.pas
@@ -6,7 +6,7 @@ uses
   InterfaceModule, System.Generics.Collections, InterfaceKernel, BaseKernel;
 
 type
-  TTransactionAnalyzerKernel = class(TBasePlatform, IPlatform)
+  TTransactionAnalyzerKernel = class(TContainer, IContainer)
     procedure RegisterModules (p_ModuleList : TList<IModule>); override;
   end;
 

--- a/Common classes/TransactionAnalyzerKernel.pas
+++ b/Common classes/TransactionAnalyzerKernel.pas
@@ -3,11 +3,11 @@ unit TransactionAnalyzerKernel;
 interface
 
 uses
-  Kernel;
+  InterfaceModule, System.Generics.Collections, InterfaceKernel, Kernel;
 
 type
-  TTransactionAnalyzerKernel = class(TKernel)
-    constructor Create;
+  TTransactionAnalyzerKernel = class(TKernel, IBaseKernel)
+    procedure RegisterModules (p_ModuleList : TList<IModule>); override;
   end;
 
 implementation
@@ -18,12 +18,13 @@ uses
 
 { TTransactionAnalyzerKernel }
 
-constructor TTransactionAnalyzerKernel.Create;
+procedure TTransactionAnalyzerKernel.RegisterModules(
+  p_ModuleList: TList<IModule>);
 begin
   inherited;
-  FObjectList.Add (TModuleCategories.Create);
-  FObjectList.Add (TModuleTransactionAnalyzer.Create);
-  FObjectList.Add (TModuleRules.Create);
+  p_ModuleList.Add (TModuleCategories.Create);
+  p_ModuleList.Add (TModuleTransactionAnalyzer.Create);
+  p_ModuleList.Add (TModuleRules.Create);
 end;
 
 end.

--- a/TransactionAnalyzerMS.dpr
+++ b/TransactionAnalyzerMS.dpr
@@ -62,7 +62,8 @@ uses
   TransactionAnalyzerKernel in 'Common classes\TransactionAnalyzerKernel.pas',
   TransactionAnalyzerKernelMS in 'TransactionAnalyzerMS\TransactionAnalyzerKernelMS.pas',
   InterfaceModuleSettings in 'Modules\Module settings\Interfaces\InterfaceModuleSettings.pas',
-  Settings in 'Modules\Module settings\Settings.pas';
+  Settings in 'Modules\Module settings\Settings.pas',
+  BaseKernel in 'Base classes\Kernel\BaseKernel.pas';
 
 {$R *.res}
 
@@ -70,6 +71,7 @@ begin
   ReportMemoryLeaksOnShutdown := true;
   Application.Initialize;
   Application.Run;
-  MainKernel := TTransactionAnalyzerKernelMS.Create;
+  MainKernel := TTransactionAnalyzerKernel.Create;
+  MainKernel.BaseKernel := TTransactionAnalyzerKernelMS.Create;
   MainKernel.Run (TfrmTransactionList, 'Analiza trasakcji');
 end.

--- a/TransactionAnalyzerMS.dpr
+++ b/TransactionAnalyzerMS.dpr
@@ -71,7 +71,7 @@ begin
   ReportMemoryLeaksOnShutdown := true;
   Application.Initialize;
   Application.Run;
-  MainKernel := TTransactionAnalyzerKernel.Create;
-  MainKernel.BaseKernel := TTransactionAnalyzerKernelMS.Create;
-  MainKernel.Run (TfrmTransactionList, 'Analiza trasakcji');
+  MainKernel := TKernel.Create (TTransactionAnalyzerKernel.Create);
+  MainKernel.BasePlatform.BasePlatform := TTransactionAnalyzerKernelMS.Create;
+  MainKernel.Open (TfrmTransactionList, 'Analiza trasakcji');
 end.

--- a/TransactionAnalyzerMS.dpr
+++ b/TransactionAnalyzerMS.dpr
@@ -72,6 +72,6 @@ begin
   Application.Initialize;
   Application.Run;
   MainKernel := TKernel.Create (TTransactionAnalyzerKernel.Create);
-  MainKernel.BasePlatform.BasePlatform := TTransactionAnalyzerKernelMS.Create;
+  MainKernel.MainContainer.Container := TTransactionAnalyzerKernelMS.Create;
   MainKernel.Open (TfrmTransactionList, 'Analiza trasakcji');
 end.

--- a/TransactionAnalyzerMS.dproj
+++ b/TransactionAnalyzerMS.dproj
@@ -208,6 +208,7 @@
         <DCCReference Include="TransactionAnalyzerMS\TransactionAnalyzerKernelMS.pas"/>
         <DCCReference Include="Modules\Module settings\Interfaces\InterfaceModuleSettings.pas"/>
         <DCCReference Include="Modules\Module settings\Settings.pas"/>
+        <DCCReference Include="Base classes\Kernel\BaseKernel.pas"/>
         <None Include="TransactionAnalyzer.todo"/>
         <None Include="TransactionAnalyzerMS.todo"/>
         <BuildConfiguration Include="Release">

--- a/TransactionAnalyzerMS/TransactionAnalyzerKernelMS.pas
+++ b/TransactionAnalyzerMS/TransactionAnalyzerKernelMS.pas
@@ -6,7 +6,7 @@ uses
   TransactionAnalyzerKernel, BaseKernel, InterfaceKernel, System.Generics.Collections, InterfaceModule;
 
 type
-  TTransactionAnalyzerKernelMS = class (TBasePlatform, IPlatform)
+  TTransactionAnalyzerKernelMS = class (TContainer, IContainer)
     procedure RegisterModules (p_ModuleList : TList<IModule>); override;
   end;
 

--- a/TransactionAnalyzerMS/TransactionAnalyzerKernelMS.pas
+++ b/TransactionAnalyzerMS/TransactionAnalyzerKernelMS.pas
@@ -3,11 +3,11 @@ unit TransactionAnalyzerKernelMS;
 interface
 
 uses
-  TransactionAnalyzerKernel;
+  TransactionAnalyzerKernel, BaseKernel, InterfaceKernel, System.Generics.Collections, InterfaceModule;
 
 type
-  TTransactionAnalyzerKernelMS = class (TTransactionAnalyzerKernel)
-    constructor Create;
+  TTransactionAnalyzerKernelMS = class (TBaseKernel, IBaseKernel)
+    procedure RegisterModules (p_ModuleList : TList<IModule>); override;
   end;
 
 implementation
@@ -17,10 +17,11 @@ uses
 
 { TTransactionAnalyzerKernelMS }
 
-constructor TTransactionAnalyzerKernelMS.Create;
+procedure TTransactionAnalyzerKernelMS.RegisterModules(
+  p_ModuleList: TList<IModule>);
 begin
   inherited;
-  FObjectList.Add (TModuleDatabase.Create);
+  p_ModuleList.Add (TModuleDatabase.Create);
 end;
 
 end.

--- a/TransactionAnalyzerMS/TransactionAnalyzerKernelMS.pas
+++ b/TransactionAnalyzerMS/TransactionAnalyzerKernelMS.pas
@@ -6,7 +6,7 @@ uses
   TransactionAnalyzerKernel, BaseKernel, InterfaceKernel, System.Generics.Collections, InterfaceModule;
 
 type
-  TTransactionAnalyzerKernelMS = class (TBaseKernel, IBaseKernel)
+  TTransactionAnalyzerKernelMS = class (TBasePlatform, IPlatform)
     procedure RegisterModules (p_ModuleList : TList<IModule>); override;
   end;
 

--- a/TransactionAnalyzerXML.dpr
+++ b/TransactionAnalyzerXML.dpr
@@ -62,7 +62,8 @@ uses
   PanelMain in 'Common classes\PanelMain.pas' {frmTransactionList: TFrame},
   TransactionAnalyzerKernel in 'Common classes\TransactionAnalyzerKernel.pas',
   ModuleDatabaseXML in 'Modules\Module database XML\ModuleDatabaseXML.pas',
-  InterfaceModuleDatabaseXML in 'Modules\Module database XML\Interfaces\InterfaceModuleDatabaseXML.pas';
+  InterfaceModuleDatabaseXML in 'Modules\Module database XML\Interfaces\InterfaceModuleDatabaseXML.pas',
+  BaseKernel in 'Base classes\Kernel\BaseKernel.pas';
 
 {$R *.res}
 
@@ -70,7 +71,8 @@ begin
   ReportMemoryLeaksOnShutdown := true;
   Application.Initialize;
   Application.Run;
-  MainKernel := TTransactionAnalyzerKernelXML.Create;
+  MainKernel := TTransactionAnalyzerKernel.Create;
+  MainKernel.BaseKernel := TTransactionAnalyzerKernelXML.Create;
   MainKernel.Run (TfrmTransactionList, 'Analiza trasakcji');
 end.
 

--- a/TransactionAnalyzerXML.dpr
+++ b/TransactionAnalyzerXML.dpr
@@ -72,7 +72,7 @@ begin
   Application.Initialize;
   Application.Run;
   MainKernel := TKernel.Create (TTransactionAnalyzerKernel.Create);
-  MainKernel.BasePlatform.BasePlatform := TTransactionAnalyzerKernelXML.Create;
+  MainKernel.MainContainer.Container := TTransactionAnalyzerKernelXML.Create;
   MainKernel.Open (TfrmTransactionList, 'Analiza trasakcji');
 end.
 

--- a/TransactionAnalyzerXML.dpr
+++ b/TransactionAnalyzerXML.dpr
@@ -71,8 +71,8 @@ begin
   ReportMemoryLeaksOnShutdown := true;
   Application.Initialize;
   Application.Run;
-  MainKernel := TTransactionAnalyzerKernel.Create;
-  MainKernel.BaseKernel := TTransactionAnalyzerKernelXML.Create;
-  MainKernel.Run (TfrmTransactionList, 'Analiza trasakcji');
+  MainKernel := TKernel.Create (TTransactionAnalyzerKernel.Create);
+  MainKernel.BasePlatform.BasePlatform := TTransactionAnalyzerKernelXML.Create;
+  MainKernel.Open (TfrmTransactionList, 'Analiza trasakcji');
 end.
 

--- a/TransactionAnalyzerXML.dproj
+++ b/TransactionAnalyzerXML.dproj
@@ -208,6 +208,7 @@
         <DCCReference Include="Common classes\TransactionAnalyzerKernel.pas"/>
         <DCCReference Include="Modules\Module database XML\ModuleDatabaseXML.pas"/>
         <DCCReference Include="Modules\Module database XML\Interfaces\InterfaceModuleDatabaseXML.pas"/>
+        <DCCReference Include="Base classes\Kernel\BaseKernel.pas"/>
         <None Include="TransactionAnalyzer.todo"/>
         <None Include="TransactionAnalyzerXML.todo"/>
         <BuildConfiguration Include="Release">

--- a/TransactionAnalyzerXML.dproj
+++ b/TransactionAnalyzerXML.dproj
@@ -5,7 +5,7 @@
         <FrameworkType>VCL</FrameworkType>
         <MainSource>TransactionAnalyzerXML.dpr</MainSource>
         <Base>True</Base>
-        <Config Condition="'$(Config)'==''">Debug</Config>
+        <Config Condition="'$(Config)'==''">Release</Config>
         <Platform Condition="'$(Platform)'==''">Win32</Platform>
         <TargetedPlatforms>1</TargetedPlatforms>
         <AppType>Application</AppType>

--- a/TransactionAnalyzerXML/TransactionAnalyzerKernelXML.pas
+++ b/TransactionAnalyzerXML/TransactionAnalyzerKernelXML.pas
@@ -6,7 +6,7 @@ uses
   InterfaceKernel, InterfaceModule, System.Generics.Collections, BaseKernel;
 
 type
-  TTransactionAnalyzerKernelXML = class (TBaseKernel, IBaseKernel)
+  TTransactionAnalyzerKernelXML = class (TBasePlatform, IPlatform)
    public
     procedure RegisterModules (p_ModuleList : TList<IModule>); override;
   end;

--- a/TransactionAnalyzerXML/TransactionAnalyzerKernelXML.pas
+++ b/TransactionAnalyzerXML/TransactionAnalyzerKernelXML.pas
@@ -6,7 +6,7 @@ uses
   InterfaceKernel, InterfaceModule, System.Generics.Collections, BaseKernel;
 
 type
-  TTransactionAnalyzerKernelXML = class (TBasePlatform, IPlatform)
+  TTransactionAnalyzerKernelXML = class (TContainer, IContainer)
    public
     procedure RegisterModules (p_ModuleList : TList<IModule>); override;
   end;

--- a/TransactionAnalyzerXML/TransactionAnalyzerKernelXML.pas
+++ b/TransactionAnalyzerXML/TransactionAnalyzerKernelXML.pas
@@ -3,26 +3,27 @@ unit TransactionAnalyzerKernelXML;
 interface
 
 uses
-  TransactionAnalyzerKernel, ModuleSettings;
+  InterfaceKernel, InterfaceModule, System.Generics.Collections, BaseKernel;
 
 type
-  TTransactionAnalyzerKernelXML = class (TTransactionAnalyzerKernel)
-  public
-    constructor Create;
+  TTransactionAnalyzerKernelXML = class (TBaseKernel, IBaseKernel)
+   public
+    procedure RegisterModules (p_ModuleList : TList<IModule>); override;
   end;
 
 implementation
 
 uses
-  ModuleDatabaseXML;
+  ModuleDatabaseXML, ModuleSettings;
 
 { TTransactionAnalyzerKernelXML }
 
-constructor TTransactionAnalyzerKernelXML.Create;
+procedure TTransactionAnalyzerKernelXML.RegisterModules(
+  p_ModuleList: TList<IModule>);
 begin
   inherited;
-  FObjectList.Add (TModuleDatabaseXML.Create);
-  FObjectList.Add (TModuleSettings.Create);
+  p_ModuleList.Add (TModuleDatabaseXML.Create);
+  p_ModuleList.Add (TModuleSettings.Create);
 end;
 
 end.

--- a/Win32/Debug/settings.xml
+++ b/Win32/Debug/settings.xml
@@ -1,1 +1,1 @@
-<settings><mainfolderpath>C:\Projekty\TransactionAnalyzer\TransactionAnalyzer\</mainfolderpath></settings>
+<settings><mainfolderpath>C:\Users\komputer1\Desktop\</mainfolderpath></settings>

--- a/categories.xml
+++ b/categories.xml
@@ -1,0 +1,1 @@
+<categories><category><id>0</id><name>bez kategorii</name></category></categories>


### PR DESCRIPTION
Wydzielono kontener, który jest skrzynką na moduły. Jądro przyjmuje jeden kontener główny. Do każdego kontenera można wpiąć jeden kontener bazowy. Umożliwia to sterowanie kolejności wczytywania i otwierania modułów.